### PR TITLE
modify setting for terminal renderer

### DIFF
--- a/mistune/__init__.py
+++ b/mistune/__init__.py
@@ -1,7 +1,7 @@
 from .markdown import Markdown
 from .block_parser import BlockParser
 from .inline_parser import InlineParser
-from .renderers import AstRenderer, HTMLRenderer, TerminalRenderer, TextRenderer
+from .renderers import AstRenderer, HTMLRenderer, TextRenderer, TerminalRenderer
 from .scanner import escape, escape_url, escape_html, unikey
 from .plugins import PLUGINS
 
@@ -27,10 +27,10 @@ def create_markdown(escape=True, renderer=None, plugins=None):
         renderer = HTMLRenderer(escape=escape)
     elif renderer == 'ast':
         renderer = AstRenderer()
-    elif renderer == 'terminal':
-        renderer = TerminalRenderer()
     elif renderer == 'text':
         renderer = TextRenderer()
+    elif renderer == 'terminal':
+        renderer = TerminalRenderer()
     else:
         raise ValueError("Unknown renderer '{}'".format(renderer))
 
@@ -51,15 +51,17 @@ html = create_markdown(
     plugins=['strikethrough', 'footnotes', 'table'],
 )
 
-terminal = create_markdown(
-    escape=False,
-    renderer='terminal',
-    plugins=['table'],
-    )
 
 text = create_markdown(
     escape=False,
     renderer='text',
+    plugins=['table'],
+    )
+
+
+terminal = create_markdown(
+    escape=False,
+    renderer='terminal',
     plugins=['table'],
     )
 
@@ -73,7 +75,7 @@ __all__ = [
     'Markdown', 'AstRenderer', 'HTMLRenderer',
     'BlockParser', 'InlineParser',
     'escape', 'escape_url', 'escape_html', 'unikey',
-    'html', 'create_markdown', 'markdown', 'terminal', 'text',
+    'html', 'create_markdown', 'markdown', 'text', 'terminal'
 ]
 
 __version__ = '2.0.0a1'

--- a/mistune/__init__.py
+++ b/mistune/__init__.py
@@ -1,7 +1,7 @@
 from .markdown import Markdown
 from .block_parser import BlockParser
 from .inline_parser import InlineParser
-from .renderers import AstRenderer, HTMLRenderer, TextRenderer
+from .renderers import AstRenderer, HTMLRenderer, TerminalRenderer, TextRenderer
 from .scanner import escape, escape_url, escape_html, unikey
 from .plugins import PLUGINS
 
@@ -27,6 +27,8 @@ def create_markdown(escape=True, renderer=None, plugins=None):
         renderer = HTMLRenderer(escape=escape)
     elif renderer == 'ast':
         renderer = AstRenderer()
+    elif renderer == 'terminal':
+        renderer = TerminalRenderer()
     elif renderer == 'text':
         renderer = TextRenderer()
     else:
@@ -49,6 +51,12 @@ html = create_markdown(
     plugins=['strikethrough', 'footnotes', 'table'],
 )
 
+terminal = create_markdown(
+    escape=False,
+    renderer='terminal',
+    plugins=['table'],
+    )
+
 text = create_markdown(
     escape=False,
     renderer='text',
@@ -65,7 +73,7 @@ __all__ = [
     'Markdown', 'AstRenderer', 'HTMLRenderer',
     'BlockParser', 'InlineParser',
     'escape', 'escape_url', 'escape_html', 'unikey',
-    'html', 'create_markdown', 'markdown', 'text',
+    'html', 'create_markdown', 'markdown', 'terminal', 'text',
 ]
 
 __version__ = '2.0.0a1'

--- a/mistune/plugins/table.py
+++ b/mistune/plugins/table.py
@@ -162,5 +162,8 @@ def plugin_table(md):
     elif md.renderer.NAME == 'ast':
         md.renderer.register('table_cell', render_ast_table_cell)
 
+    elif md.renderer.NAME == 'terminal':
+        md.block.register_rule('table', TABLE_PATTERN, text_parse_and_render_table)
+
     elif md.renderer.NAME == 'text':
         md.block.register_rule('table', TABLE_PATTERN, text_parse_and_render_table)

--- a/mistune/plugins/table.py
+++ b/mistune/plugins/table.py
@@ -162,8 +162,5 @@ def plugin_table(md):
     elif md.renderer.NAME == 'ast':
         md.renderer.register('table_cell', render_ast_table_cell)
 
-    elif md.renderer.NAME == 'terminal':
-        md.block.register_rule('table', TABLE_PATTERN, text_parse_and_render_table)
-
-    elif md.renderer.NAME == 'text':
+    elif md.renderer.NAME == 'text' or md.renderer.NAME == 'terminal':
         md.block.register_rule('table', TABLE_PATTERN, text_parse_and_render_table)

--- a/mistune/renderers.py
+++ b/mistune/renderers.py
@@ -200,59 +200,6 @@ class HTMLRenderer(BaseRenderer):
         return '<li>' + text + '</li>\n'
 
 
-class TerminalRenderer(BaseRenderer):
-    NAME = 'terminal'
-    IS_TREE = False
-
-    def __init__(self):
-        super(TerminalRenderer, self).__init__()
-
-    def text(self, text):
-        return text
-
-    def heading(self, text, level):
-        return '#' * level + ' ' + text.strip() + '\n\n'
-
-    def list(self, text, ordered, level, start=None):
-        assert not ordered
-        return text
-
-    def list_item(self, text, level):
-        return ' ' * (level-1) + '- ' + text + '\n'
-
-    def block_text(self, text):
-        return text
-
-    def thematic_break(self):
-        return '\n---\n\n'
-
-    def paragraph(self, text):
-        return text.strip('\n') + '\n\n'
-
-    def link(self, link, text=None, title=None):
-        return f'[{text}]({link})'
-
-    def block_quote(self, text):
-        return '\n'.join(['> ' + line for line in text.strip().splitlines()]) + '\n'
-
-    def newline(self):
-        return '\n'
-
-    def block_code(self, code, info=None):
-        return f"```{info or ''}\n" + code.strip('\n') + "\n```\n\n"
-
-    def codespan(self, text):
-        return f'`{text}`'
-
-    def strong(self, text):
-        return '\033[1m' + text + '\033[0m'
-
-    def linebreak(self):
-        return '\n'
-
-    def table(self, text):
-        return text
-
 class TextRenderer(BaseRenderer):
     NAME = 'text'
     IS_TREE = False
@@ -305,3 +252,20 @@ class TextRenderer(BaseRenderer):
 
     def table(self, text):
         return text
+
+
+class TerminalRenderer(TextRenderer):
+    NAME = 'terminal'
+    IS_TREE = False
+
+    def __init__(self):
+        super(TerminalRenderer, self).__init__()
+
+    def block_code(self, code, info=None):
+        return f"\033[48;100m{info or ''}\n" + code.strip('\n') + "\n\033[0m\n\n"
+
+    def codespan(self, text):
+        return f'\033[48;100m{text}\033[0m'
+
+    def strong(self, text):
+        return '\033[1m' + text + '\033[0m'

--- a/mistune/renderers.py
+++ b/mistune/renderers.py
@@ -245,7 +245,7 @@ class TextRenderer(BaseRenderer):
         return f'`{text}`'
 
     def strong(self, text):
-        return '**' + text + '**'
+        return '\033[1m' + text + '\033[0m'
 
     def table(self, table):
         from bs4 import BeautifulSoup

--- a/mistune/renderers.py
+++ b/mistune/renderers.py
@@ -200,6 +200,59 @@ class HTMLRenderer(BaseRenderer):
         return '<li>' + text + '</li>\n'
 
 
+class TerminalRenderer(BaseRenderer):
+    NAME = 'terminal'
+    IS_TREE = False
+
+    def __init__(self):
+        super(TerminalRenderer, self).__init__()
+
+    def text(self, text):
+        return text
+
+    def heading(self, text, level):
+        return '#' * level + ' ' + text.strip() + '\n\n'
+
+    def list(self, text, ordered, level, start=None):
+        assert not ordered
+        return text
+
+    def list_item(self, text, level):
+        return ' ' * (level-1) + '- ' + text + '\n'
+
+    def block_text(self, text):
+        return text
+
+    def thematic_break(self):
+        return '\n---\n\n'
+
+    def paragraph(self, text):
+        return text.strip('\n') + '\n\n'
+
+    def link(self, link, text=None, title=None):
+        return f'[{text}]({link})'
+
+    def block_quote(self, text):
+        return '\n'.join(['> ' + line for line in text.strip().splitlines()]) + '\n'
+
+    def newline(self):
+        return '\n'
+
+    def block_code(self, code, info=None):
+        return f"```{info or ''}\n" + code.strip('\n') + "\n```\n\n"
+
+    def codespan(self, text):
+        return f'`{text}`'
+
+    def strong(self, text):
+        return '\033[1m' + text + '\033[0m'
+
+    def linebreak(self):
+        return '\n'
+
+    def table(self, text):
+        return text
+
 class TextRenderer(BaseRenderer):
     NAME = 'text'
     IS_TREE = False
@@ -245,7 +298,7 @@ class TextRenderer(BaseRenderer):
         return f'`{text}`'
 
     def strong(self, text):
-        return '\033[1m' + text + '\033[0m'
+        return '**' + text + '**'
 
     def linebreak(self):
         return '\n'


### PR DESCRIPTION
I created a separate PR to address the changes needed for terminal rendering syntax. So far I only find one that need to change.

On the other note, I think we can also use this PR to decide on whether we should commit to use the name `terminal_renderer` or `text` and unify the mixed use of `text` and `terminal` across the changes before we update the PR to merge to mistune.